### PR TITLE
Ignore traffic with id=1 (that's our own aircraft)

### DIFF
--- a/MainViewModel.cs
+++ b/MainViewModel.cs
@@ -277,7 +277,8 @@ namespace fs2ff
 
         private async Task SimConnectTrafficReceived(Traffic tfk, uint id)
         {
-            if (DataTrafficEnabled)
+            // Ignore traffic with id=1, that's our own aircraft
+            if (DataTrafficEnabled && id != 1)
             {
                 await _dataSender.Send(tfk, id).ConfigureAwait(false);
             }


### PR DESCRIPTION
On SkyDemon it always looks like another plane is at the same position that you are.
It turns out that in the traffic data your own aircraft is broadcasted and _apparently_  it has always the id "1" (always was when I tested, but not found the information in the docs).

This solves #17 by simply ignoring traffic with id=1